### PR TITLE
Use modules to read/write source

### DIFF
--- a/commands/modules.js
+++ b/commands/modules.js
@@ -21,7 +21,6 @@ export async function interactivelyChangeModule(system, vmEditor, moduleName, ne
   // options.write, options.eval, ..
   options = obj.merge({targetModule: moduleName}, options);
   moduleName = await system.normalize(moduleName);
-  await system.moduleWrite(moduleName, newSource);
   await system.moduleSourceChange(moduleName, newSource, options);
   await vmEditor.updateModuleList();
   return moduleName;

--- a/interfaces/http-interface.js
+++ b/interfaces/http-interface.js
@@ -184,6 +184,10 @@ try {
     return this.runEvalAndStringify(`lively.modules.module(${JSON.stringify(moduleName)}).format();`);
   }
 
+  moduleRead(moduleName) {
+    return this.runEvalAndStringify(`lively.modules.module(${JSON.stringify(moduleName)}).source(${JSON.stringify(newSource)}, ${JSON.stringify(options)})`);
+  }
+
   moduleSourceChange(moduleName, newSource, options) {
     return this.runEvalAndStringify(`lively.modules.module(${JSON.stringify(moduleName)}).changeSource(${JSON.stringify(newSource)}, ${JSON.stringify(options)})`);
   }

--- a/interfaces/interface.js
+++ b/interfaces/interface.js
@@ -84,16 +84,13 @@ export class AbstractCoreInterface {
   forgetModule(name, opts)                                 { todo("forgetModule") }
   reloadModule(name, opts)                                 { todo("reloadModule") }
   moduleFormat(moduleName)                                 { todo("moduleFormat") }
+  moduleRead(moduleName)                                   { todo("moduleRead") }
   moduleSourceChange(moduleName, newSource, options)       { todo("moduleSourceChange") }
   importsAndExportsOf(modId, sourceOrAst)                  { todo("importsAndExportsOf") }
   keyValueListOfVariablesInModule(moduleName, sourceOrAst) { todo("keyValueListOfVariablesInModule") }
 
-  async moduleRead(moduleName) {
-    return this.getModule(moduleName).source();
-  }
-
-  async moduleWrite(moduleName, source) {
-    return this.getModule(moduleName).changeSource(source);
+  moduleWrite(moduleName, newSource) {
+    return this.moduleSourceChange(moduleName, newSource);
   }
 
 }

--- a/interfaces/interface.js
+++ b/interfaces/interface.js
@@ -89,11 +89,11 @@ export class AbstractCoreInterface {
   keyValueListOfVariablesInModule(moduleName, sourceOrAst) { todo("keyValueListOfVariablesInModule") }
 
   async moduleRead(moduleName) {
-    return this.resourceRead(await this.normalize(moduleName));
+    return this.getModule(moduleName).source();
   }
 
   async moduleWrite(moduleName, source) {
-    return this.resourceWrite(await this.normalize(moduleName), source);
+    return this.getModule(moduleName).changeSource(source);
   }
 
 }

--- a/interfaces/local-system.js
+++ b/interfaces/local-system.js
@@ -124,7 +124,11 @@ export class LocalCoreInterface extends AbstractCoreInterface {
   moduleFormat(moduleName) {
     return modules.module(moduleName).format();
   }
-
+  
+  moduleRead(moduleName) {
+    return modules.module(moduleName).source();
+  }
+ 
   moduleSourceChange(moduleName, newSource, options) {
     return modules.module(moduleName).changeSource(newSource, options);
   }


### PR DESCRIPTION
Modules know how to read and write their own source code. Therefore, this should also be used by `lively-system-interface` in order to avoid inconsistencies. 

In order to support reading and writing remote modules, I would suggest to introduce a special url scheme for modules that live in a remote world, e.g. `lively+remote://package/file.js` or `lively+remote://<fullModuleID>`. That way modules can handle reads, write and evals in a special way. This would also avoid having multiple different system interfaces.
